### PR TITLE
Allow custom events to bubble

### DIFF
--- a/owlcarousel/owl.carousel.js
+++ b/owlcarousel/owl.carousel.js
@@ -2615,7 +2615,7 @@ Custom events list:
 
 			//evt.initEvent(event, false, true );
 
-			evt.initCustomEvent(event, false, true, data);
+			evt.initCustomEvent(event, true, true, data);
 			return this.dom.el.dispatchEvent(evt);
 
 		} else if (!this.dom.el.dispatchEvent){


### PR DESCRIPTION
Event bubbling would allow much more convenient integration. There are all sorts of situations where this is expected behaviour – document-wide listeners and deferred listeners (eg `$fragment.on( 'owl.change', 'owl-carousel', handlerFn )`).
