### PR TITLE
Remove trailing comma to fix Closure compile

### DIFF
--- a/dist/owl.carousel.js
+++ b/dist/owl.carousel.js
@@ -3202,7 +3202,7 @@
 					e.data = this.hashes[window.location.hash.substring(1)];
 				}
 				this.filling = e.property.name == 'item' && e.property.value && e.property.value.is(':empty');
-			}, this),
+			}, this)
 		};
 
 		// register the event handlers

--- a/src/js/owl.hash.js
+++ b/src/js/owl.hash.js
@@ -43,7 +43,7 @@
 					e.data = this.hashes[window.location.hash.substring(1)];
 				}
 				this.filling = e.property.name == 'item' && e.property.value && e.property.value.is(':empty');
-			}, this),
+			}, this)
 		};
 
 		// register the event handlers


### PR DESCRIPTION
This comma causes Closure compilation to fail with the error 

```
ERROR - Parse error. Internet Explorer has a non-standard intepretation of trailing commas. Arrays will have the wrong length and objects will not parse at all.
        };
         ^

1 error(s), 0 warning(s)

```

Removing it eliminates the error.
