### PR TITLE
Bugfix in 'destroy' function in hash plugin

### DIFF
--- a/src/js/owl.hash.js
+++ b/src/js/owl.hash.js
@@ -96,7 +96,7 @@
 		$(window).off('hashchange.owl.navigation');
 
 		for (handler in this.handlers) {
-			this.owl.dom.$el.off(handler, this.handlers[handler]);
+			this.core.dom.$el.off(handler, this.handlers[handler]);
 		}
 		for (property in Object.getOwnPropertyNames(this)) {
 			typeof this[property] != 'function' && (this[property] = null);


### PR DESCRIPTION
Changed old variable 'owl' to 'core'.
