### PR TITLE
fixed slideBy 'page' without dots

### DIFF
--- a/dist/owl.carousel.js
+++ b/dist/owl.carousel.js
@@ -2972,7 +2972,7 @@
 			options.slideBy = Math.min(options.slideBy, options.items);
 		}
 
-		if (options.dots) {
+		if (options.dots || options.slideBy == 'page') {
 			this.pages = [];
 
 			for (i = lower, j = 0, k = 0; i < upper; i++) {

--- a/src/js/owl.navigation.js
+++ b/src/js/owl.navigation.js
@@ -234,7 +234,7 @@
 			options.slideBy = Math.min(options.slideBy, options.items);
 		}
 
-		if (options.dots) {
+		if (options.dots || options.slideBy == 'page') {
 			this.pages = [];
 
 			for (i = lower, j = 0, k = 0; i < upper; i++) {


### PR DESCRIPTION
pages are now being calculated even if dots are disabled (if slideBy ==
‘page’)
