### PR TITLE
Point bower to a specific file instead of a folder

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -2,7 +2,7 @@
   "name": "owl.carousel",
   "version": "2.0.0-beta.2.4",
   "main": [
-    "./dist/"
+    "./dist/owl.carousel.js"
   ],
   "dependencies": {
     "jquery": ">= 1.8.3"


### PR DESCRIPTION
I was unable to use this plugin with [debowerify](https://github.com/eugeneware/debowerify), because the main property in `bower.json` didn't point to any `.js` files.

If you look at [this specific line of code](https://github.com/eugeneware/debowerify/blob/35dd46ea42996a17d0c9ccca507b1a66677a1743/index.js#L92), you can see that debowerify only includes items that have a `.js` extension, when the `main` property in `bower.json` is set to an array.

By specifically pointing to `./dist/owl.carousel.js`, I am able to use debowerify to simply require the plugin from within a file like so: `require('owl.carousel')`. This is preferable as I am using gulp w/ browserify to build and concatenate my vendor script into one file. I would prefer this over having to include Owlify as a standalone script in the head of my app.
