### PR TITLE
Added option to use only items matching a selector to create carousel it...

### DIFF
--- a/src/js/owl.carousel.js
+++ b/src/js/owl.carousel.js
@@ -234,6 +234,7 @@
 		nestedItemSelector: false,
 		itemElement: 'div',
 		stageElement: 'div',
+		userItem: false,
 
 		// Classes and Names
 		themeClass: 'owl-theme',
@@ -429,7 +430,11 @@
 		this.$element.append(this.$stage.parent());
 
 		// append content
-		this.replace(this.$element.children().not(this.$stage.parent()));
+		if (this.settings.userItem) {
+			this.replace(this.$element.find(this.settings.userItem).not(this.$stage.parent()));
+		} else {
+			this.replace(this.$element.children().not(this.$stage.parent()));
+		}
 
 		// update view
 		this.refresh();


### PR DESCRIPTION
...ems.

The idea behind this is to allow the user to set a class to the items that are going to be part of the carousel. If this option is not false, then it will be used to create items and the rest of the childrens will be ignored. Example:

```
$(".owl-carousel").owlCarousel({
    userItem: 'div.myItem'
  }
);

<div class="owl-carrousel">
    <div class="myItem"> Content </div>
    <div class="myItem"> Content </div>
    <script> Content </script> <!-- This will be ignored and will not be a carrousel item >
    <div class="myItem"> Content </div>
</div>
```
