### PR TITLE
Corrects typo in `trigger`

### DIFF
--- a/src/js/owl.carousel.js
+++ b/src/js/owl.carousel.js
@@ -1630,7 +1630,7 @@
 				}
 			});
 
-			this.register(event);
+			this.register(name);
 			this.$element.trigger(event);
 
 			if (this.settings && typeof this.settings[handler] === 'function') {


### PR DESCRIPTION
The line was copied from another point and I forgot to change the parameter `name`. Fixes #267.
