### PR TITLE
Bugfix function call

### DIFF
--- a/src/js/owl.carousel.js
+++ b/src/js/owl.carousel.js
@@ -1634,7 +1634,7 @@
 			this.$element.trigger(event);
 
 			if (this.settings && typeof this.settings[handler] === 'function') {
-				this.settings[handler].apply(this, event);
+				this.settings[handler].call(this, event);
 			}
 		}
 


### PR DESCRIPTION
- Making correct call of function (apply expects an array)
- Fixes error in IE8 when having more then one instance of owl carousel (ex: syncing 2 carousels)
