### PR TITLE
allow users to click links containing hashes and don't change owlCarousel slide

### DIFF
--- a/src/js/owl.hash.js
+++ b/src/js/owl.hash.js
@@ -62,15 +62,15 @@
 		$(window).on('hashchange.owl.navigation', $.proxy(function() {
 			var hash = window.location.hash.substring(1),
 				items = this._core.$stage.children(),
-				position = this._hashes[hash] && items.index(this._hashes[hash]) || 0;
+                position = this._hashes[hash] && items.index(this._hashes[hash]);
 
-			if (!hash) {
-				return false;
-			}
+            if (!hash || position === false) {
+                return false;
+            }
 
 			this._core.to(this._core.relative(position), false, true);
 		}, this));
-	}
+	};
 
 	/**
 	 * Default options.
@@ -78,7 +78,7 @@
 	 */
 	Hash.Defaults = {
 		URLhashListener: false
-	}
+	};
 
 	/**
 	 * Destroys the plugin.


### PR DESCRIPTION
before:
- user clicks an anchor containing a hash
- OwlCarousel doesn't find/understand hash
- OwlCarousel goes to slide in position zero

now: 
- user clicks an anchor containing a hash
- OwlCarousel doesn't find/understand hash
- OwlCarousel doesn't change slide position
