### PR TITLE
Avoid slide line breaks inside stage

### DIFF
--- a/src/js/owl.carousel.js
+++ b/src/js/owl.carousel.js
@@ -310,7 +310,7 @@
 		filter: [ 'width', 'items', 'settings' ],
 		run: function() {
 			var i, n, width = (this.width() / this.settings.items).toFixed(3), css = {
-				'width': Math.abs(this._coordinates[this._coordinates.length - 1]) + this.settings.stagePadding * 2,
+				'width': Math.ceil(Math.abs(this._coordinates[this._coordinates.length - 1])) + this.settings.stagePadding * 2,
 				'padding-left': this.settings.stagePadding || '',
 				'padding-right': this.settings.stagePadding || ''
 			};


### PR DESCRIPTION
Added Math.ceil to stage width calculation to ensure that slide don't wrap due to px breaks. Otherwise the last slide sometimes wraps to the next line and doubles the slider height.
