### PR TITLE
Update location hash when slide changes

### DIFF
--- a/src/js/owl.hash.js
+++ b/src/js/owl.hash.js
@@ -55,7 +55,7 @@
 					.children()
 					.eq(this._core.current())
 					.find('[data-hash]')
-					.attr('data-hash')
+					.attr('data-hash');
 				if (hash) {
 					window.location.hash = hash;
 				}


### PR DESCRIPTION
change the document.location hash when a carousel slide changes and the data-hash attribute is used
