### PR TITLE
Make some more class names configurable

### DIFF
--- a/docs_src/data/classes.json
+++ b/docs_src/data/classes.json
@@ -54,6 +54,12 @@
     "desc":     "Navigation container class."
   },
   {
+    "name":     "navDisabledContainerClass",
+    "type":     "String",
+    "Default":  "disabled",
+    "desc":     "Additional class for disabled navigation container."
+  },
+  {
     "name":     "navClass",
     "type":     "Array",
     "Default":  "['owl-prev','owl-next']",
@@ -84,9 +90,39 @@
     "desc":     "Auto height class."
   },
   {
+    "name":     "activeClass",
+    "type":     "String",
+    "Default":  "active",
+    "desc":     "Active slide(s) class. Attached to slides that are currently visible."
+  },
+  {
+    "name":     "centerClass",
+    "type":     "String",
+    "Default":  "center",
+    "desc":     "Centered slide(s) class. Attached to slides that are currently centered. Only works with center option."
+  },
+  {
+    "name":     "clonedClass",
+    "type":     "String",
+    "Default":  "cloned",
+    "desc":     "Cloned slides class. Attached to slides that were cloned in case loop option is used."
+  },
+  {
     "name":     "responsiveClass",
     "type":     "String|Boolean",
     "Default":  "false",
     "desc":     "Optional helper class. Add '<responsiveClass>-<breakpoint>' class to main element. Can be used to stylize content on given breakpoint."
+  },
+  {
+    "name":     "videoFrameClass",
+    "type":     "String",
+    "Default":  "owl-video-frame",
+    "desc":     "Video frame class."
+  },
+  {
+    "name":     "videoPlayingClass",
+    "type":     "String",
+    "Default":  "owl-video-playing",
+    "desc":     "Attached to slide that is currently playing a video."
   }
 ]

--- a/src/js/owl.carousel.js
+++ b/src/js/owl.carousel.js
@@ -218,7 +218,10 @@
 		itemClass: 'owl-item',
 		stageClass: 'owl-stage',
 		stageOuterClass: 'owl-stage-outer',
-		grabClass: 'owl-grab'
+		grabClass: 'owl-grab',
+		clonedClass: 'cloned',
+		activeClass: 'active',
+		centerClass: 'center'
 	};
 
 	/**
@@ -285,10 +288,10 @@
 			}
 
 			this._clones = clones;
-			this.$stage.children('.cloned').remove();
+			this.$stage.children('.' + this.options.clonedClass).remove();
 
-			$(append).addClass('cloned').appendTo(this.$stage);
-			$(prepend).addClass('cloned').prependTo(this.$stage);
+			$(append).addClass(this.options.clonedClass).appendTo(this.$stage);
+			$(prepend).addClass(this.options.clonedClass).prependTo(this.$stage);
 		}
 	}, {
 		filter: [ 'width', 'items', 'settings' ],
@@ -367,12 +370,12 @@
 				}
 			}
 
-			this.$stage.children('.active').removeClass('active');
-			this.$stage.children(':eq(' + matches.join('), :eq(') + ')').addClass('active');
+			this.$stage.children('.' + this.options.activeClass).removeClass(this.options.activeClass);
+			this.$stage.children(':eq(' + matches.join('), :eq(') + ')').addClass(this.options.activeClass);
 
 			if (this.settings.center) {
-				this.$stage.children('.center').removeClass('center');
-				this.$stage.children().eq(this.current()).addClass('center');
+				this.$stage.children('.' + this.options.centerClass).removeClass(this.options.centerClass);
+				this.$stage.children().eq(this.current()).addClass(this.options.centerClass);
 			}
 		}
 	} ];
@@ -1309,7 +1312,7 @@
 			this._plugins[i].destroy();
 		}
 
-		this.$stage.children('.cloned').remove();
+		this.$stage.children('.' + this.options.clonedClass).remove();
 
 		this.$stage.unwrap();
 		this.$stage.children().contents().unwrap();

--- a/src/js/owl.navigation.js
+++ b/src/js/owl.navigation.js
@@ -132,6 +132,7 @@
 		navContainer: false,
 		navContainerClass: 'owl-nav',
 		navClass: [ 'owl-prev', 'owl-next' ],
+		navDisabledContainerClass: 'disabled',
 		slideBy: 1,
 		dotClass: 'owl-dot',
 		dotsClass: 'owl-dots',
@@ -152,7 +153,7 @@
 
 		// create DOM structure for relative navigation
 		this._controls.$relative = (settings.navContainer ? $(settings.navContainer)
-			: $('<div>').addClass(settings.navContainerClass).appendTo(this.$element)).addClass('disabled');
+			: $('<div>').addClass(settings.navContainerClass).appendTo(this.$element)).addClass(settings.navDisabledContainerClass);
 
 		this._controls.$previous = $('<' + settings.navElement + '>')
 			.addClass(settings.navClass[0])
@@ -178,7 +179,7 @@
 		}
 
 		this._controls.$absolute = (settings.dotsContainer ? $(settings.dotsContainer)
-			: $('<div>').addClass(settings.dotsClass).appendTo(this.$element)).addClass('disabled');
+			: $('<div>').addClass(settings.dotsClass).appendTo(this.$element)).addClass(settings.navDisabledContainerClass);
 
 		this._controls.$absolute.on('click', 'div', $.proxy(function(e) {
 			var index = $(e.target).parent().is(this._controls.$absolute)
@@ -263,14 +264,14 @@
 			disabled = this._core.items().length <= settings.items,
 			index = this._core.relative(this._core.current());
 
-		this._controls.$relative.toggleClass('disabled', !settings.nav || disabled);
+		this._controls.$relative.toggleClass(settings.navDisabledContainerClass, !settings.nav || disabled);
 
 		if (settings.nav && !settings.loop && !settings.rewind) {
-			this._controls.$previous.toggleClass('disabled', index <= this._core.minimum(true));
-			this._controls.$next.toggleClass('disabled', index >= this._core.maximum(true));
+			this._controls.$previous.toggleClass(settings.navDisabledContainerClass, index <= this._core.minimum(true));
+			this._controls.$next.toggleClass(settings.navDisabledContainerClass, index >= this._core.maximum(true));
 		}
 
-		this._controls.$absolute.toggleClass('disabled', !settings.dots || disabled);
+		this._controls.$absolute.toggleClass(settings.navDisabledContainerClass, !settings.dots || disabled);
 
 		if (settings.dots) {
 			difference = this._pages.length - this._controls.$absolute.children().length;
@@ -283,8 +284,8 @@
 				this._controls.$absolute.children().slice(difference).remove();
 			}
 
-			this._controls.$absolute.find('.active').removeClass('active');
-			this._controls.$absolute.children().eq($.inArray(this.current(), this._pages)).addClass('active');
+			this._controls.$absolute.find('.' + this._core.options.activeClass).removeClass(this._core.options.activeClass);
+			this._controls.$absolute.children().eq($.inArray(this.current(), this._pages)).addClass(this._core.options.activeClass);
 		}
 	};
 

--- a/src/js/owl.video.js
+++ b/src/js/owl.video.js
@@ -52,7 +52,7 @@
 			}, this),
 			'refreshed.owl.carousel': $.proxy(function(e) {
 				if (e.namespace && this._core.is('resizing')) {
-					this._core.$stage.find('.cloned .owl-video-frame').remove();
+					this._core.$stage.find('.' + this._core.settings.clonedClass + ' .' + this._core.settings.videoFrameClass).remove();
 				}
 			}, this),
 			'changed.owl.carousel': $.proxy(function(e) {
@@ -92,7 +92,9 @@
 	Video.Defaults = {
 		video: false,
 		videoHeight: false,
-		videoWidth: false
+		videoWidth: false,
+		videoPlayingClass: 'owl-video-playing',
+		videoFrameClass: 'owl-video-frame'
 	};
 
 	/**
@@ -201,8 +203,8 @@
 	 */
 	Video.prototype.stop = function() {
 		this._core.trigger('stop', null, 'video');
-		this._playing.find('.owl-video-frame').remove();
-		this._playing.removeClass('owl-video-playing');
+		this._playing.find('.' + this._core.settings.videoFrameClass).remove();
+		this._playing.removeClass(this._core.settings.videoPlayingClass);
 		this._playing = null;
 		this._core.leave('playing');
 		this._core.trigger('stopped', null, 'video');
@@ -241,9 +243,9 @@
 				'" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe>';
 		}
 
-		$('<div class="owl-video-frame">' + html + '</div>').insertAfter(item.find('.owl-video'));
+		$('<div class="' + this._core.settings.videoFrameClass + '">' + html + '</div>').insertAfter(item.find('.owl-video'));
 
-		this._playing = item.addClass('owl-video-playing');
+		this._playing = item.addClass(this._core.settings.videoPlayingClass);
 	};
 
 	/**
@@ -256,7 +258,7 @@
 		var element = document.fullscreenElement || document.mozFullScreenElement ||
 				document.webkitFullscreenElement;
 
-		return element && $(element).parent().hasClass('owl-video-frame');
+		return element && $(element).parent().hasClass(this._core.settings.videoFrameClass);
 	};
 
 	/**


### PR DESCRIPTION
This allows for more class name customization. In our particular use case we need this, because we are using BEM-style class names, but this change might also avoid conflicts with other classes, because most of the now optional class names are not `owl-` namespaced.
