### PR TITLE
Use matchMedia instead of minWidth

### DIFF
--- a/src/js/owl.carousel.js
+++ b/src/js/owl.carousel.js
@@ -204,7 +204,6 @@
 
 		responsive: {},
 		responsiveRefreshRate: 200,
-		responsiveBaseElement: window,
 
 		fallbackEasing: 'swing',
 
@@ -501,7 +500,7 @@
 			settings = $.extend({}, this.options);
 		} else {
 			$.each(overwrites, function(breakpoint) {
-        if (this.options.responsiveBaseElement.matchMedia(breakpoint).matches) {
+        if (window.matchMedia(breakpoint).matches) {
           match = breakpoint;
         }
 			});
@@ -1227,9 +1226,7 @@
 	 */
 	Owl.prototype.viewport = function() {
 		var width;
-		if (this.options.responsiveBaseElement !== window) {
-			width = $(this.options.responsiveBaseElement).width();
-		} else if (window.innerWidth) {
+		if (window.innerWidth) {
 			width = window.innerWidth;
 		} else if (document.documentElement && document.documentElement.clientWidth) {
 			width = document.documentElement.clientWidth;


### PR DESCRIPTION
This is referenced to https://github.com/OwlFonk/OwlCarousel2/issues/327
I removed the proposed options and replaced the width check with matchMedia. 

This is just to start this up, because I believe this is a really needed feature I'd like to see in Owlcarousel soon.  Would love some feedback about this. I guess at least documentation should be adjusted and I don't know what I missed.
