### PR TITLE
use `substring(0, 1)` instead of `[0]`

### DIFF
--- a/src/js/owl.carousel.js
+++ b/src/js/owl.carousel.js
@@ -158,7 +158,7 @@
 		}, this));
 
 		$.each(Owl.Plugins, $.proxy(function(key, plugin) {
-			this._plugins[key[0].toLowerCase() + key.slice(1)]
+			this._plugins[key.substring(0, 1).toLowerCase() + key.slice(1)]
 				= new plugin(this);
 		}, this));
 


### PR DESCRIPTION
because IE7 does not support the latter one.
