### PR TITLE
Fix lazy loading position 0

### DIFF
--- a/src/js/owl.lazyload.js
+++ b/src/js/owl.lazyload.js
@@ -46,7 +46,7 @@
 					var settings = this._core.settings,
 						n = (settings.center && Math.ceil(settings.items / 2) || settings.items),
 						i = ((settings.center && n * -1) || 0),
-						position = ((e.property && e.property.value) || this._core.current()) + i,
+						position = (e.property && e.property.value !== undefined ? e.property.value : this._core.current()) + i,
 						clones = this._core.clones().length,
 						load = $.proxy(function(i, v) { this.load(v) }, this);
 


### PR DESCRIPTION
This fixes the scenario where you try to lazy load index 0 from a change event (e.g. when `startPosition` is 1).

0 is falsy so `position` was being set as `this._core.current()` instead of `e.property.value`.