### PR TITLE
Check this please.

### DIFF
--- a/src/js/owl.lazyload.js
+++ b/src/js/owl.lazyload.js
@@ -33,7 +33,7 @@
 		 * @type {Object}
 		 */
 		this._handlers = {
-			'initialized.owl.carousel change.owl.carousel': $.proxy(function(e) {
+			'initialized.owl.carousel change.owl.carousel refreshed.owl.carousel': $.proxy(function(e) {
 				if (!e.namespace) {
 					return;
 				}
@@ -42,7 +42,7 @@
 					return;
 				}
 
-				if ((e.property && e.property.name == 'position') || e.type == 'initialized') {
+				if ((e.property && e.property.name == 'position') || e.type == 'initialized' || e.type == 'refreshed' ) {
 					var settings = this._core.settings,
 						n = (settings.center && Math.ceil(settings.items / 2) || settings.items),
 						i = ((settings.center && n * -1) || 0),


### PR DESCRIPTION
Adding ' refreshed ' in the function of avoiding LazyLoad initialize the owl again. Also a bug when using the replace function . Tell me if I 'm right plx  :).
