### PR TITLE
Fix Vertical Drag Failure

### DIFF
--- a/src/js/owl.carousel.js
+++ b/src/js/owl.carousel.js
@@ -739,10 +739,6 @@
 
 			$(document).on('mousemove.owl.core touchmove.owl.core', $.proxy(this.onDragMove, this));
 
-			if (Math.abs(delta.x) < Math.abs(delta.y) && this.is('valid')) {
-				return;
-			}
-
 			event.preventDefault();
 
 			this.enter('dragging');


### PR DESCRIPTION
Removed some code that caused the drag handler on the carousel to fail if the initial drag was of a vertical velocity. I tried to search for the reason for this code existing, both through testing and reading the code, but couldn't see the reason for it's existence. If this code has purpose, could someone chime in and explain what it is and I can figure out how to work around that, but as it currently stands to me, I see no benefit to this code and it leaves the carousel feeling very unresponsive as it is very easy to drag vertically initially by accident.
