### PR TITLE
Responsive classes never get added in Owl.prototype.setup

### DIFF
--- a/src/js/owl.carousel.js
+++ b/src/js/owl.carousel.js
@@ -218,7 +218,7 @@
 		loadedClass: 'owl-loaded',
 		loadingClass: 'owl-loading',
 		rtlClass: 'owl-rtl',
-		responsiveClass: 'owl-responsive',
+		responsiveClass: false,
 		dragClass: 'owl-drag',
 		itemClass: 'owl-item',
 		stageClass: 'owl-stage',
@@ -498,15 +498,14 @@
 			overwrites = this.options.responsive,
 			match = -1,
 			settings = null,
+			breakpoints = [],
 			breakpointClasses = [];
 
 		if (!overwrites) {
 			settings = $.extend({}, this.options);
 		} else {
 			$.each(overwrites, function(breakpoint) {
-				if (settings.responsiveClass) {
-					breakpointClasses.push(settings.responsiveClass + '-' + breakpoint);
-				}
+				breakpoints.push(breakpoint);
 				if (breakpoint <= viewport && breakpoint > match) {
 					match = Number(breakpoint);
 				}
@@ -516,9 +515,14 @@
 			delete settings.responsive;
 
 			// responsive class
-			if (settings.responsiveClass) {
+			if (typeof settings.responsiveClass === 'string' && breakpoints.length) {
+
+				$.each(breakpoints, function(i, breakpoint) {
+					breakpointClasses.push(settings.responsiveClass + '-' + breakpoint);
+				});
+
 				this.$element.removeClass(breakpointClasses.join(' '));
-				this.$element.addClass(this.options.responsiveClass + '-' + match);
+				this.$element.addClass(settings.responsiveClass + '-' + match);
 			}
 		}
 

--- a/src/js/owl.carousel.js
+++ b/src/js/owl.carousel.js
@@ -497,12 +497,16 @@
 		var viewport = this.viewport(),
 			overwrites = this.options.responsive,
 			match = -1,
-			settings = null;
+			settings = null,
+			breakpointClasses = [];
 
 		if (!overwrites) {
 			settings = $.extend({}, this.options);
 		} else {
 			$.each(overwrites, function(breakpoint) {
+				if (settings.responsiveClass) {
+					breakpointClasses.push(settings.responsiveClass + '-' + breakpoint);
+				}
 				if (breakpoint <= viewport && breakpoint > match) {
 					match = Number(breakpoint);
 				}
@@ -513,9 +517,8 @@
 
 			// responsive class
 			if (settings.responsiveClass) {
-				this.$element.attr('class',
-					this.$element.attr('class').replace(new RegExp('(' + this.options.responsiveClass + '-)\\S+\\s', 'g'), '$1' + match)
-				);
+				this.$element.removeClass(breakpointClasses.join(' '));
+				this.$element.addClass(this.options.responsiveClass + '-' + match);
 			}
 		}
 


### PR DESCRIPTION
Responsive classes aren't being added - only replaced.  Also, docs indicate default should be `false` but it's actually `'owl-responsive'`.

If there's defined breakpoints and `typeof settings.responsiveClass == 'string'` this change will:
-  collect all possible class names and use $.removeClass to remove them
-  add the current responsiveClass

(I'm using responsive classes still for non-IE8 folk - some ~~nasty~~ creative margin adjustments to .owl-stage)
