### PR TITLE
.center class hangs around when responsive options

### DIFF
--- a/src/js/owl.carousel.js
+++ b/src/js/owl.carousel.js
@@ -427,8 +427,8 @@
 			this.$stage.children('.active').removeClass('active');
 			this.$stage.children(':eq(' + matches.join('), :eq(') + ')').addClass('active');
 
+			this.$stage.children('.center').removeClass('center');
 			if (this.settings.center) {
-				this.$stage.children('.center').removeClass('center');
 				this.$stage.children().eq(this.current()).addClass('center');
 			}
 		}


### PR DESCRIPTION
This change always removes left-over .center classes before checking if a new one should be set.

Otherwise, .center class can hang around when settings.center is set using responsive options (and responsive element changes size)
