### PR TITLE
Fixed when transform property is applied

### DIFF
--- a/src/scss/owl.lazyload.scss
+++ b/src/scss/owl.lazyload.scss
@@ -9,7 +9,7 @@
 				transition: opacity 400ms ease;
 		}
 
-		img {
+		img.owl-lazy {
 			transform-style: preserve-3d;
 		}
 	}


### PR DESCRIPTION
The transform-style property should probably only be applied if using the owl-lazy load class.