### PR TITLE
Sync switched to Linked

### DIFF
--- a/src/js/owl.linked.js
+++ b/src/js/owl.linked.js
@@ -91,7 +91,7 @@
      * Destroys the plugin.
      * @protected
      */
-    Sync.prototype.destroy = function() {
+    Linked.prototype.destroy = function() {
         var handler, property;
 
         for (handler in this._handlers) {


### PR DESCRIPTION
On line 94 of the code, instead of Linked, there was a undefined Sync variable, probably from OwlCarousel Sync plugin code.

The Sync variable was switched to Linked.