### PR TITLE
Documentation : plugin api mistake

### DIFF
--- a/docs_src/templates/pages/docs/dev-plugin-api.hbs
+++ b/docs_src/templates/pages/docs/dev-plugin-api.hbs
@@ -26,7 +26,7 @@ Plugin scaffolding:
 
 	PluginName = function(scope){
 		this.owl = scope;
-		this.owl._options = $.extend(PluginName.Defaults, this.owl.options);
+		this.owl._options = $.extend({}, PluginName.Defaults, this.owl.options);
 
 		//link callback events with owl carousel here
 	}


### PR DESCRIPTION
Without {}, "PluginName.Defaults" object is merged with "this.owl.options"
