### PR TITLE
Fix Owl.prototype.maximum

### DIFF
--- a/src/js/owl.carousel.js
+++ b/src/js/owl.carousel.js
@@ -510,6 +510,9 @@
 			});
 
 			settings = $.extend({}, this.options, overwrites[match]);
+			if (typeof settings.stagePadding === 'function') {
+				settings.stagePadding = settings.stagePadding();
+			}
 			delete settings.responsive;
 
 			// responsive class

--- a/src/js/owl.carousel.js
+++ b/src/js/owl.carousel.js
@@ -1011,6 +1011,7 @@
 
 	/**
 	 * Gets the maximum position for the current item.
+     * @TODO: Work on the binary search (remove workaround for issue #1419)
 	 * @public
 	 * @param {Boolean} [relative=false] - Whether to return an absolute position or a relative position.
 	 * @returns {Number}

--- a/src/js/owl.carousel.js
+++ b/src/js/owl.carousel.js
@@ -1011,39 +1011,37 @@
 
 	/**
 	 * Gets the maximum position for the current item.
-     * @TODO: Work on the binary search (remove workaround for issue #1419)
+     * @todo: find a prettier workaround #1419
 	 * @public
 	 * @param {Boolean} [relative=false] - Whether to return an absolute position or a relative position.
 	 * @returns {Number}
 	 */
 	Owl.prototype.maximum = function(relative) {
-        var settings = this.settings,
+		var settings = this.settings,
 			maximum = this._coordinates.length,
 			boundary = Math.abs(this._coordinates[maximum - 1]) - this._width,
 			i = -1, j,
-            revert,
-            width,
+            revert = settings.rtl ? 1 : -1,
+            width = this.$stage.width() - this.$element.width(),
             coordinate;
 
 		if (settings.loop) {
 			maximum = this._clones.length / 2 + this._items.length - 1;
 		} else if (settings.autoWidth || settings.merge) {
-			if (!settings.loop){
-                revert = settings.rtl ? 1 : -1;
-                width = this.$stage.width() - this.$element.width();
-				while (coordinate = this.coordinates(i)) {
-					if (coordinate * revert >= width) {
-						break;
-					}
-					maximum = ++i;
-				}
-			} else {
-				//binary search
-				while (maximum - i > 1) {
-					Math.abs(this._coordinates[j = maximum + i >> 1]) < boundary
-						? i = j : maximum = j;
-				}
-			}
+            if (!settings.loop) {
+                while (coordinate = this.coordinates(i)) {
+                    if (coordinate * revert >= width) {
+                        break;
+                    }
+                    maximum = ++i;
+                }
+            } else {
+                //binary search
+                while (maximum - i > 1) {
+                    Math.abs(this._coordinates[j = maximum + i >> 1]) < boundary
+                        ? i = j : maximum = j;
+                }
+            }
 		} else if (settings.center) {
 			maximum = this._items.length - 1;
 		} else {

--- a/src/js/owl.carousel.js
+++ b/src/js/owl.carousel.js
@@ -1016,18 +1016,32 @@
 	 * @returns {Number}
 	 */
 	Owl.prototype.maximum = function(relative) {
-		var settings = this.settings,
+        var settings = this.settings,
 			maximum = this._coordinates.length,
 			boundary = Math.abs(this._coordinates[maximum - 1]) - this._width,
-			i = -1, j;
+			i = -1, j,
+            revert,
+            width,
+            coordinate;
 
 		if (settings.loop) {
 			maximum = this._clones.length / 2 + this._items.length - 1;
 		} else if (settings.autoWidth || settings.merge) {
-			// binary search
-			while (maximum - i > 1) {
-				Math.abs(this._coordinates[j = maximum + i >> 1]) < boundary
-					? i = j : maximum = j;
+			if (!settings.loop){
+                revert = settings.rtl ? 1 : -1;
+                width = this.$stage.width() - this.$element.width();
+				while (coordinate = this.coordinates(i)) {
+					if (coordinate * revert >= width) {
+						break;
+					}
+					maximum = ++i;
+				}
+			} else {
+				//binary search
+				while (maximum - i > 1) {
+					Math.abs(this._coordinates[j = maximum + i >> 1]) < boundary
+						? i = j : maximum = j;
+				}
 			}
 		} else if (settings.center) {
 			maximum = this._items.length - 1;


### PR DESCRIPTION
@CracyCrazz 
Fix : it could not scroll to the last item when set autowidth-true and loop-false.
It is related #1419 

It is ok in owl.carousel.2.0.0-beta.2.4;
JSFiddle Link: https://jsfiddle.net/JSDavi/7z1th3cx/

But it doesn't work in this new version of owl.carousel.2.1.0;
JSFiddle Link: https://jsfiddle.net/JSDavi/rtvc5exr/

Even in owl.carousel.2.1.4, it doesn't work;
JSFiddle Link: https://jsfiddle.net/JSDavi/cotyqt6x/1/

Also in owl.carousel.2.1.5, it doesn't work;
JSFiddle Link: https://jsfiddle.net/JSDavi/689q9zLd/