### PR TITLE
Remove engine from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,9 +45,6 @@
     "pretty": "^1.0.0",
     "qunitjs": "^1.18.0"
   },
-  "engines": {
-    "node": "~0.10.28"
-  },
   "keywords": [
     "responsive",
     "carousel",


### PR DESCRIPTION
The engine flag should be either removed or updated. Since this is a package for the browser, I'd say remove it since it isn't really relevant.

Creating this PR since yarn throws an error if the engine is incompatible.

https://github.com/yarnpkg/yarn