### PR TITLE
Remove references to old maintainer from documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,13 +34,13 @@ Example:
 
 Feature requests are welcome, but please take a moment to find out whether your idea fits with the scope and aims of the project. It's up to you to make a strong case to convince the project's developers of the merits of this feature.
 
-To get approval for your feature request, please create an issue on the issue tracker with as much detail and context as possible. We'll take a look at it and then [hopefully] apply the "[approved for development](https://github.com/smashingboxes/OwlCarousel2/labels/approved%20for%20development)" tag so someone can get to work on it!
+To get approval for your feature request, please create an issue on the issue tracker with as much detail and context as possible. We'll take a look at it and then [hopefully] apply the "[approved for development](https://github.com/OwlCarousel2/OwlCarousel2/labels/approved%20for%20development)" tag so someone can get to work on it!
 
 ### Pull requests
 
 Good pull requests are a fantastic help. They should remain focused in scope and avoid containing unrelated commits.
 
-**Going forward, we will only be accepting pull requests that are linked to an issue that is marked "[approved for development](https://github.com/smashingboxes/OwlCarousel2/labels/approved%20for%20development)."** If there is something you'd like to implement that isn't already approved (like a new feature, documentation updates, or some sort of refactoring), create an issue on the issue tracker! Only submitting pull requests for issues that have been approved helps us, the maintainers, get new code into the project quickly and helps prevent you from spending a lot of time on something that might never get merged into the project. See [Feature Requests](https://github.com/smashingboxes/OwlCarousel2/blob/develop/CONTRIBUTING.md#feature-requests) for more info.
+**Going forward, we will only be accepting pull requests that are linked to an issue that is marked "[approved for development](https://github.com/OwlCarousel2/OwlCarousel2/labels/approved%20for%20development)."** If there is something you'd like to implement that isn't already approved (like a new feature, documentation updates, or some sort of refactoring), create an issue on the issue tracker! Only submitting pull requests for issues that have been approved helps us, the maintainers, get new code into the project quickly and helps prevent you from spending a lot of time on something that might never get merged into the project. See [Feature Requests](https://github.com/OwlCarousel2/OwlCarousel2/blob/develop/CONTRIBUTING.md#feature-requests) for more info.
 
 Adhering to the following process is the best way to get your work included in the project:
 
@@ -49,7 +49,7 @@ Adhering to the following process is the best way to get your work included in t
     ```bash
     git clone https://github.com/<your-username>/OwlCarousel2.git
     cd OwlCarousel2
-    git remote add upstream https://github.com/smashingboxes/OwlCarousel2.git
+    git remote add upstream https://github.com/OwlCarousel2/OwlCarousel2.git
     ```
 
   2. If you cloned a while ago, get the latest changes from upstream:

--- a/docs_src/templates/pages/docs/started-faq.hbs
+++ b/docs_src/templates/pages/docs/started-faq.hbs
@@ -43,7 +43,7 @@ Yes! Go to [Github]({{ pkg.bugs.url }}) issues page and ask for a feature.
 ------
 #### I need help!
 
-First visit [Github]({{ pkg.bugs.url }}), then look again at documentation and demos. Finally, if you’re still struggling, send us an email: <opensource@smashingboxes.com>. Don't forget to add [jsfiddle](https://jsfiddle.net/) or a link to your demo/example website!
+First visit [Github]({{ pkg.bugs.url }}), then look again at documentation and demos. Don't forget to add [jsfiddle](https://jsfiddle.net/) or a link to your demo/example website!
 
 ------
 #### Does it have infinity scroll/circle/loop slides?

--- a/docs_src/templates/pages/docs/support-contact.hbs
+++ b/docs_src/templates/pages/docs/support-contact.hbs
@@ -14,7 +14,7 @@ tags:
 ## Contact
 ------
 
-If you have any questions please contact us via email <opensource@smashingboxes.com>. If you are looking for help then the best place to ask a question is [Github]({{ pkg.bugs.url }}). Also don't forget to add a [jsfiddle](https://jsfiddle.net/) or a link to your demo/example website!
+If you are looking for help then the best place to ask a question is [Github]({{ pkg.bugs.url }}). Also don't forget to add a [jsfiddle](https://jsfiddle.net/) or a link to your demo/example website!
 
 ### Report a bug
 


### PR DESCRIPTION
## Why?
Some emails and links point at dead URLs.

## What changed?
- Removed old email from documentation
- Fixed URLs in Contributing guidelines to point at current GitHub URL 