### PR TITLE
Fixing option animateIn on documentation

### DIFF
--- a/docs/docs/api-options.html
+++ b/docs/docs/api-options.html
@@ -317,7 +317,7 @@
               <br /> Default: <code>false</code></p>
             <p>Class for CSS3 animation out.</p>
             <hr>
-            <h4 id="animateinclass">animateInClass</h4>
+            <h4 id="animateinclass">animateIn</h4>
             <p>Type: <code>String/Boolean</code>
               <br /> Default: <code>false</code></p>
             <p>Class for CSS3 animation in.</p>


### PR DESCRIPTION
The option animateInClass doesn't work actually, I used the animateIn and it works fine. So I believe that this documentation has the wrong option.

And I find in the js file if have anything called animateInClass and not exists, only animateIn.