### PR TITLE
Fixes detect viewport method to use warn instead throw

### DIFF
--- a/src/js/owl.carousel.js
+++ b/src/js/owl.carousel.js
@@ -1271,7 +1271,7 @@
 		} else if (document.documentElement && document.documentElement.clientWidth) {
 			width = document.documentElement.clientWidth;
 		} else {
-			throw 'Can not detect viewport width.';
+			console.warn('Can not detect viewport width.');
 		}
 		return width;
 	};


### PR DESCRIPTION
Hi... I'm receiving a lot of error event in Sentry about `Uncaught Can not detect viewport width.`.

I would suggest to not throw an error since users can't do anything about this. Also, It will use up my error reporting quota. 

How about print a console warning or error though?

https://github.com/OwlCarousel2/OwlCarousel2/issues/1704