### PR TITLE
Allow package file to expose CSS

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "version": "2.2.1",
   "homepage": "https://github.com/OwlCarousel2/OwlCarousel2",
   "main": "./dist/owl.carousel.js",
+  "style": "./dist/assets/owl.carousel.css",
   "author": {
     "name": "David Deutsch",
     "email": "deutsch@medienpark.net",


### PR DESCRIPTION
Adding this field, npm modules like [sass-module-importer](https://www.npmjs.com/package/sass-module-importer) or [npm-css](https://www.npmjs.com/package/npm-css) can import the CSS from the Owl Carousel `npm_modules` folder.

EG.
`@import 'owl-carousel';`

NOTE - this is not standardised, but is widely used in node modules

Fix for issue [#1767](https://github.com/OwlCarousel2/OwlCarousel2/issues/1767)