### PR TITLE
Update owl.autoplay.js

### DIFF
--- a/src/js/owl.autoplay.js
+++ b/src/js/owl.autoplay.js
@@ -118,6 +118,7 @@
 		this._paused = false;
 
 		if (this._core.is('rotating')) {
+			this._setAutoPlayInterval();
 			return;
 		}
 


### PR DESCRIPTION
[Issue #1464:](https://github.com/OwlCarousel2/OwlCarousel2/issues/1464)

Now when pausing carousel with mouse over the plugin's layer (with autoplayHoverPause set to true), plugin doesn't continue animation when mouse leaving. 

This is a solution.