### PR TITLE
fix two problems related to destroy

### DIFF
--- a/src/js/owl.carousel.js
+++ b/src/js/owl.carousel.js
@@ -1408,7 +1408,7 @@
 		this.$stage.unwrap();
 		this.$stage.children().contents().unwrap();
 		this.$stage.children().unwrap();
-
+		this.$stage.remove();
 		this.$element
 			.removeClass(this.options.refreshClass)
 			.removeClass(this.options.loadingClass)

--- a/src/js/owl.navigation.js
+++ b/src/js/owl.navigation.js
@@ -207,7 +207,11 @@
 			this.$element.off(handler, this._handlers[handler]);
 		}
 		for (control in this._controls) {
-			this._controls[control].remove();
+			if(control === '$relative' && settings.navContainer){
+				this._controls[control].html('');
+			}else{
+				this._controls[control].remove();
+			}
 		}
 		for (override in this.overides) {
 			this._core[override] = this._overrides[override];


### PR DESCRIPTION
1. Navigation.prototype.destroy() destroys users' custom `navContainer` erroneously.
2. Owl.prototype.destroy() fails to remove `owl-stage`.

closes #1768 