### PR TITLE
allow faster bootstrap with less forced reflow and dom manipulation

### DIFF
--- a/docs/assets/owlcarousel/owl.carousel.js
+++ b/docs/assets/owlcarousel/owl.carousel.js
@@ -215,6 +215,7 @@
 		fallbackEasing: 'swing',
 
 		info: false,
+		checkVisibility: true,
 
 		nestedItemSelector: false,
 		itemElement: 'div',

--- a/src/js/owl.autorefresh.js
+++ b/src/js/owl.autorefresh.js
@@ -71,7 +71,7 @@
 			return;
 		}
 
-		this._visible = this._core.$element.is(':visible');
+		this._visible = this._core.isVisible();
 		this._interval = window.setInterval($.proxy(this.refresh, this), this._core.settings.autoRefreshInterval);
 	};
 
@@ -79,7 +79,7 @@
 	 * Refreshes the element.
 	 */
 	AutoRefresh.prototype.refresh = function() {
-		if (this._core.$element.is(':visible') === this._visible) {
+		if (this._core.isVisible() === this._visible) {
 			return;
 		}
 

--- a/src/js/owl.carousel.js
+++ b/src/js/owl.carousel.js
@@ -438,6 +438,65 @@
 	} ];
 
 	/**
+	 * Create the stage DOM element
+	 */
+	Owl.prototype.initializeStage = function() {
+		this.$stage = this.$element.find('.' + this.settings.stageClass);
+
+		// if the stage is already in the DOM, grab it and skip stage initialization
+		if (this.$stage.length) {
+			return;
+		}
+
+		this.$element.addClass(this.options.loadingClass);
+
+		// create stage
+		this.$stage = $('<' + this.settings.stageElement + ' class="' + this.settings.stageClass + '"/>')
+			.wrap('<div class="' + this.settings.stageOuterClass + '"/>');
+
+		// append stage
+		this.$element.append(this.$stage.parent());
+	};
+
+	/**
+	 * Create item DOM elements
+	 */
+	Owl.prototype.initializeItems = function() {
+		var $items = this.$element.find('.owl-item');
+
+		// if the items are already in the DOM, grab them and skip item initialization
+		if ($items.length) {
+			this._items = $items.get().map(function(item) {
+				return $(item);
+			});
+
+			this._mergers = this._items.map(function() {
+				return 1;
+			});
+
+			this.refresh();
+
+			return;
+		}
+
+		// append content
+		this.replace(this.$element.children().not(this.$stage.parent()));
+
+		// check visibility
+		if (this.isVisible()) {
+			// update view
+			this.refresh();
+		} else {
+			// invalidate width
+			this.invalidate('width');
+		}
+
+		this.$element
+			.removeClass(this.options.loadingClass)
+			.addClass(this.options.loadedClass);
+	};
+
+	/**
 	 * Initializes the carousel.
 	 * @protected
 	 */
@@ -458,36 +517,25 @@
 			}
 		}
 
-		this.$element.addClass(this.options.loadingClass);
-
-		// create stage
-		this.$stage = $('<' + this.settings.stageElement + ' class="' + this.settings.stageClass + '"/>')
-			.wrap('<div class="' + this.settings.stageOuterClass + '"/>');
-
-		// append stage
-		this.$element.append(this.$stage.parent());
-
-		// append content
-		this.replace(this.$element.children().not(this.$stage.parent()));
-
-		// check visibility
-		if (this.$element.is(':visible')) {
-			// update view
-			this.refresh();
-		} else {
-			// invalidate width
-			this.invalidate('width');
-		}
-
-		this.$element
-			.removeClass(this.options.loadingClass)
-			.addClass(this.options.loadedClass);
+		this.initializeStage();
+		this.initializeItems();
 
 		// register event handlers
 		this.registerEventHandlers();
 
 		this.leave('initializing');
 		this.trigger('initialized');
+	};
+
+	/**
+	 * @returns {Boolean} visibility of $element
+	 *                    if you know the carousel will always be visible you can set `checkVisibility` to `false` to
+	 *                    prevent the expensive browser layout forced reflow the $element.is(':visible') does
+	 */
+	Owl.prototype.isVisible = function() {
+		return this.settings.checkVisibility
+			? this.$element.is(':visible')
+			: true;
 	};
 
 	/**
@@ -645,7 +693,7 @@
 			return false;
 		}
 
-		if (!this.$element.is(':visible')) {
+		if (!this.isVisible()) {
 			return false;
 		}
 
@@ -1211,7 +1259,7 @@
 		this.speed(this.duration(current, position, speed));
 		this.current(position);
 
-		if (this.$element.is(':visible')) {
+		if (this.isVisible()) {
 			this.update();
 		}
 	};


### PR DESCRIPTION
Hey,

we love the OwlCarousel and have it heavily at use in production. On some pages up to 4 carousels at the same time.

The problem: On old android devices (like Galaxy S4/S5ish), DOM manipulation and forced reflows are very slow. And it get worse the more complex the page becomes.

With this PR we were able to reduce the render time of a page with 4 carousels from 10 seconds to 2,5 seconds on a Galaxy S4.

In this plunkr the difference is not that severe as its just a blank page and the items are simple text, but you already see the impact:

### default
plunkr: http://plnkr.co/edit/c52107vIiWWNJDYPKJqV?p=preview
4 carousel ~ 100ms
![image](https://cloud.githubusercontent.com/assets/905328/24912638/ff852444-1ece-11e7-9d5a-5ee18e9a6707.png)

### fast
plunkr: http://plnkr.co/edit/CSRUwANcqOgD4S7LAmDm?p=preview
4 carousel ~ 55ms
![image](https://cloud.githubusercontent.com/assets/905328/24913378/4b077352-1ed1-11e7-919f-d5e578721f51.png)

## Trick 1

Instead of
```twig
      <div class="owl-carousel owl-theme carousel-default">
        <div class="item bg-navy">item</div>
      </div>
```

we do
```twig
      <div class="owl-carousel owl-theme carousel-fast owl-loaded owl-drag">
        <div class="owl-stage-outer">
          <div class="owl-stage">
            <div class="owl-item">
              <div class="item bg-navy">item</div>
            </div>
          </div>
        </div>
      </div>
```

So in the initialize method the OwlCarousel does not need to move the DOM around anymore. The simple way still works! But you may provide the final DOM and this PR will skip that part.

## Trick 2
We call OwlCarousel with `{checkVisibility: false}` that tells it, that the carousel is always visible and just skip all `is(':visible')` checks
```javascript
$('.carousel').owlCarousel({checkVisibility: false});
```

Thats gets rid of some performance punishing force reflows.



What do you think?