### PR TITLE
Fix typos in events.json and api-events.html

### DIFF
--- a/docs/docs/api-events.html
+++ b/docs/docs/api-events.html
@@ -261,7 +261,7 @@ function callback(event) {
               <br />Parameter: <code>[position, speed]</code>
               <br/>
             </p>
-            <p>Goes to postion.</p>
+            <p>Goes to position.</p>
             <hr>
             <h4 id="destroy-owl-carousel">destroy.owl.carousel</h4>
             <p>Type: <code>triggerable</code>

--- a/docs_src/data/events.json
+++ b/docs_src/data/events.json
@@ -93,7 +93,7 @@
         "name": "to.owl.carousel",
         "type": "triggerable",
         "param": "[position, speed]",
-        "desc": "Goes to postion."
+        "desc": "Goes to position."
       },
       {
         "name": "destroy.owl.carousel",


### PR DESCRIPTION
Changed word from 'postion' to 'position'. 