### PR TITLE
Fix infinite loop

### DIFF
--- a/src/js/owl.carousel.js
+++ b/src/js/owl.carousel.js
@@ -330,12 +330,13 @@
 
 			repeat /= 2;
 
-			while (repeat--) {
+			while (repeat > 0) {
 				// Switch to only using appended clones
 				clones.push(this.normalize(clones.length / 2, true));
 				append = append + items[clones[clones.length - 1]][0].outerHTML;
 				clones.push(this.normalize(items.length - 1 - (clones.length - 1) / 2, true));
 				prepend = items[clones[clones.length - 1]][0].outerHTML + prepend;
+				repeat -= 1;
 			}
 
 			this._clones = clones;


### PR DESCRIPTION
This is a bit of an edge case, but it is possible to set the [`items` options](https://owlcarousel2.github.io/OwlCarousel2/docs/api-options.html) to a fractional number (e.g. 2.5 items per page instead of 3). This actually works well, except for these lines here. For example, if `items` is set to 2.5, and there are 4 images in the carousel, then `repeat` becomes 1.5. The first `repeat--` makes `repeat` equal .5, then the next loop `repeat` equals -.5. Because the loop is supposed to terminate when `repeat` is 0 (falsy), the loop instead continues to run, and `repeat` goes down to negative infinity. Eventually the browser runs out of memory with strange errors (Chrome just says "Invalid string length"). The proposed change fixes this problem.