### PR TITLE
Improving autoplay behavior

### DIFF
--- a/src/js/owl.autoplay.js
+++ b/src/js/owl.autoplay.js
@@ -122,6 +122,11 @@
 		autoplaySpeed: false
 	};
 
+	/**
+	 * Transition to the next slide and set a timeout for the next transition.
+	 * @private
+	 * @param {Number} [speed] - The animation speed for the animations.
+	 */
 	Autoplay.prototype._next = function(speed) {
 		this._call = window.setTimeout(
 			$.proxy(this._next, this, speed),
@@ -135,8 +140,7 @@
 	}
 
 	/**
-	 * Read the current timer value. Should only be used when the timer is
-	 * paused.
+	 * Reads the current timer value when the timer is playing.
 	 * @public
 	 */
 	Autoplay.prototype.read = function() {
@@ -158,20 +162,24 @@
 
 		timeout = timeout || this._core.settings.autoplayTimeout;
 
+		// Calculate the elapsed time since the last transition. If the carousel
+		// wasn't playing this calculation will yield zero.
 		elapsed = Math.min(this._time % (this._timeout || timeout), timeout);
 
 		if (this._paused) {
+			// Start the clock.
 			this._time = this.read();
 			this._paused = false;
 		} else {
+			// Clear the active timeout to allow replacement.
 			window.clearTimeout(this._call);
 		}
 
+		// Adjust the origin of the timer to match the new timeout value.
 		this._time += this.read() % timeout - elapsed;
 
-		this._call = window.setTimeout($.proxy(this._next, this, speed), timeout - elapsed);
-
 		this._timeout = timeout;
+		this._call = window.setTimeout($.proxy(this._next, this, speed), timeout - elapsed);
 	};
 
 	/**
@@ -180,6 +188,7 @@
 	 */
 	Autoplay.prototype.stop = function() {
 		if (this._core.is('rotating')) {
+			// Reset the clock.
 			this._time = 0;
 			this._paused = true;
 
@@ -194,6 +203,7 @@
 	 */
 	Autoplay.prototype.pause = function() {
 		if (this._core.is('rotating') && !this._paused) {
+			// Pause the clock.
 			this._time = this.read();
 			this._paused = true;
 

--- a/src/js/owl.autoplay.js
+++ b/src/js/owl.autoplay.js
@@ -62,9 +62,10 @@
 					} else {
 						this.stop();
 					}
-				} else if (e.namespace && e.property.name === 'position') {
-					this.stop();
-					this.play();
+				} else if (e.namespace && e.property.name === 'position' && this._paused) {
+					// Reset the timer. This code is triggered when the position
+					// of the carousel was changed through user interaction.
+					this._time = 0;
 				}
 			}, this),
 			'initialized.owl.carousel': $.proxy(function(e) {

--- a/src/js/owl.autoplay.js
+++ b/src/js/owl.autoplay.js
@@ -154,17 +154,17 @@
 			this._core.enter('rotating');
 		}
 		if (this._paused) {
+			var elapsed;
+
 			timeout = timeout || this._core.settings.autoplayTimeout;
 
-			this._time += Math.min(this._time % (this._timeout || timeout), timeout) - this._time % timeout;
+			elapsed = Math.min(this._time % (this._timeout || timeout), timeout);
+			this._time += elapsed - this._time % timeout;
 
 			this._time = this.read();
 			this._paused = false;
 
-			this._call = window.setTimeout(
-				$.proxy(this._next, this, speed),
-				timeout * (Math.floor(this.read() / timeout) + 1) - this.read()
-			);
+			this._call = window.setTimeout($.proxy(this._next, this, speed), timeout - elapsed);
 
 			this._timeout = timeout;
 		}

--- a/src/js/owl.autoplay.js
+++ b/src/js/owl.autoplay.js
@@ -150,24 +150,28 @@
 	 * @param {Number} [speed] - The animation speed for the animations.
 	 */
 	Autoplay.prototype.play = function(timeout, speed) {
+		var elapsed;
+
 		if (!this._core.is('rotating')) {
 			this._core.enter('rotating');
 		}
+
+		timeout = timeout || this._core.settings.autoplayTimeout;
+
+		elapsed = Math.min(this._time % (this._timeout || timeout), timeout);
+
 		if (this._paused) {
-			var elapsed;
-
-			timeout = timeout || this._core.settings.autoplayTimeout;
-
-			elapsed = Math.min(this._time % (this._timeout || timeout), timeout);
-			this._time += elapsed - this._time % timeout;
-
 			this._time = this.read();
 			this._paused = false;
-
-			this._call = window.setTimeout($.proxy(this._next, this, speed), timeout - elapsed);
-
-			this._timeout = timeout;
+		} else {
+			window.clearTimeout(this._call);
 		}
+
+		this._time += this.read() % timeout - elapsed;
+
+		this._call = window.setTimeout($.proxy(this._next, this, speed), timeout - elapsed);
+
+		this._timeout = timeout;
 	};
 
 	/**

--- a/test/index.html
+++ b/test/index.html
@@ -13,7 +13,9 @@
 		<script src="../node_modules/qunitjs/qunit/qunit.js"></script>
 		<script src="../src/js/owl.carousel.js" data-cover></script>
 		<script src="../src/js/owl.support.js" data-cover></script>
+		<script src="../src/js/owl.autoplay.js" data-cover></script>
 		<script src="unit/core.js" defer></script>
+		<script src="unit/autoplay.js" defer></script>
 	</head>
 	<body>
 		<div id="qunit"></div>

--- a/test/unit/autoplay.js
+++ b/test/unit/autoplay.js
@@ -1,0 +1,68 @@
+module('Autoplay tests');
+
+function FakeClock() {
+	var value = 1;
+
+	this.tick = function(duration) {
+		value += duration;
+	}
+
+	Date = function() {
+		this.getTime = function() {
+			return value;
+		}
+	}
+}
+
+function change_timeout(autoplay, first, second, time) {
+	var clock = new FakeClock();
+
+	autoplay.stop();
+
+	autoplay.play(first);
+
+	clock.tick(time);
+
+	autoplay.pause();
+	autoplay.play(second);
+}
+
+test('stopping the autoplay timer', function() {
+	expect(2);
+
+	var clock = new FakeClock();
+
+	var carousel = $('#simple').owlCarousel().data('owl.carousel');
+	var autoplay = carousel._plugins.autoplay;
+
+	clock.tick(1);
+
+	autoplay.stop();
+	autoplay.play();
+
+	equal(autoplay.read(), 0);
+
+	autoplay.pause();
+	autoplay.play();
+
+	equal(autoplay.read(), 0);
+});
+
+test('changing autoplay timeout values', function() {
+	expect(4);
+
+	var carousel = $('#simple').owlCarousel().data('owl.carousel');
+	var autoplay = carousel._plugins.autoplay;
+
+	change_timeout(autoplay, 2000, 3000, 3000);
+	equal(autoplay.read() % 3000, 1000);
+
+	change_timeout(autoplay, 4000, 5000, 12000);
+	equal(autoplay.read() % 5000, 0);
+
+	change_timeout(autoplay, 5000, 4000, 12000);
+	equal(autoplay.read() % 4000, 2000);
+
+	change_timeout(autoplay, 11000, 6000, 19000);
+	equal(autoplay.read() % 6000, 0);
+});

--- a/test/unit/autoplay.js
+++ b/test/unit/autoplay.js
@@ -1,6 +1,8 @@
 module('Autoplay tests');
 
 function FakeClock() {
+	// Instantiate a new controllable clock which overrides the built in Date
+	// class on construction.
 	var value = 1;
 
 	this.tick = function(duration) {
@@ -14,16 +16,23 @@ function FakeClock() {
 	}
 }
 
-function change_timeout(autoplay, first, second, time) {
+function change_timeout(autoplay, first, second, wait) {
 	var clock = new FakeClock();
 
-	autoplay.stop();
+	// This is a helper function to test multiple consecutive play calls with
+	// different timeout values. Four steps will be completed by this function:
 
+	// 1. The autoplay will be played in a stopped state with the first timeout.
+	autoplay.stop();
 	autoplay.play(first);
 
-	clock.tick(time);
+	// 2. Time will be forwarded a given wait time.
+	clock.tick(wait);
 
+	// 3. The autoplay will be paused.
 	autoplay.pause();
+
+	// 4. The autoplay will be played with the second timeout.
 	autoplay.play(second);
 }
 
@@ -54,15 +63,24 @@ test('changing autoplay timeout values', function() {
 	var carousel = $('#simple').owlCarousel().data('owl.carousel');
 	var autoplay = carousel._plugins.autoplay;
 
+	// Changing the timeout from 2000 to 3000 after 3000 ticks should maintain
+	// the elapsed time (1000) since the last transition.
 	change_timeout(autoplay, 2000, 3000, 3000);
 	equal(autoplay.read() % 3000, 1000);
 
+	// Changing the timeout from 4000 to 5000 after 12000 ticks should maintain
+	// the elapsed time (0) since the last transition.
 	change_timeout(autoplay, 4000, 5000, 12000);
 	equal(autoplay.read() % 5000, 0);
 
+	// Changing the timeout from 5000 to 4000 after 12000 ticks should maintain
+	// the elapsed time (2000) since the last transition.
 	change_timeout(autoplay, 5000, 4000, 12000);
 	equal(autoplay.read() % 4000, 2000);
 
+	// Changing the timeout from 11000 to 6000 after 19000 ticks should reset
+	// the elapsed timer value (7000) since the last transition to 0, because
+	// it is larger than the timeout value.
 	change_timeout(autoplay, 11000, 6000, 19000);
 	equal(autoplay.read() % 6000, 0);
 });


### PR DESCRIPTION
This pull request proposes an improvement to the autoplay internal timing mechanism. It makes the autoplay plugin easier to understand and fixes #440/#993, #1038, #1179, #1426/#1727, #1464, #1471/#1620/#1827/#1860/#1911, #1518, #1655 and #1948. The pull request is an updated version of #1039 and works with the current state of the codebase.

### Improvements
- Resuming after a pause will make sure the time already elapsed before the pause will be subtracted from the new timeout. This also works when changing timeout values after resuming. 
- Animation timings can be changed on the fly (by calling `play` with the new `timeout` value). If the new timeout is shorter than the time already elapsed since the last animation, the carousel will animate instantly. If it is longer, the carousel will wait for the remaining time before animating.
- Timeout changes will now be visible after a mouse hover if used with autoplayHoverPause (however, as noted above, a timeout change can also be forced by calling `play`).
- The autoplay animations will not drift from the system clock. If using a 3000ms timeout the carousel will animate at 3000ms, 6000ms, 9000ms and so on.
- Includes some tests for the internal timing mechanism.

### Internal changes
- The autoplay plugin now has a very basic internal clock (see `this._time` property) to keep track of animation timings.
- The state of the plugin is governed by `this._core.is('rotating')` which acts as an on/off switch for the plugin and additionally by `this._paused`. This allows to make the distinction between a playing plugin and a paused but still active plugin.
- Impact on minified js is small, around 300 bytes.

Might also impact and resolve other related bugs like #1600 and #1862.