### PR TITLE
Resolve null pointer with navigation destroy

### DIFF
--- a/src/js/owl.navigation.js
+++ b/src/js/owl.navigation.js
@@ -220,7 +220,8 @@
 	 * @protected
 	 */
 	Navigation.prototype.destroy = function() {
-		var handler, control, property, override;
+		var handler, control, property, override, settings;
+		settings = this._core.settings;
 
 		for (handler in this._handlers) {
 			this.$element.off(handler, this._handlers[handler]);


### PR DESCRIPTION
When destroying the owl carousel, there is a null pointer being thrown by Navigation.  The `settings` object is never declared [here](https://github.com/OwlCarousel2/OwlCarousel2/blob/a731e93393b9c60757bc94ccb9d946763127c3f2/src/js/owl.navigation.js#L229).

Relates to #1778 