### PR TITLE
Allow lazy loading for source tags

### DIFF
--- a/dist/owl.carousel.js
+++ b/dist/owl.carousel.js
@@ -1903,7 +1903,7 @@
 
 		$elements.each($.proxy(function(index, element) {
 			var $element = $(element), image,
-				url = (window.devicePixelRatio > 1 && $element.attr('data-src-retina')) || $element.attr('data-src');
+                url = (window.devicePixelRatio > 1 && $element.attr('data-src-retina')) || $element.attr('data-src') || $element.attr('data-srcset');
 
 			this._core.trigger('load', { element: $element, url: url }, 'lazy');
 
@@ -1912,6 +1912,10 @@
 					$element.css('opacity', 1);
 					this._core.trigger('loaded', { element: $element, url: url }, 'lazy');
 				}, this)).attr('src', url);
+            } else if($element.is('source')) {
+                $element.one('load.owl.lazy', $.proxy(function() {
+                    this._core.trigger('loaded', { element: $element, url: url }, 'lazy');
+                }, this)).attr('srcset', url);
 			} else {
 				image = new Image();
 				image.onload = $.proxy(function() {

--- a/src/js/owl.lazyload.js
+++ b/src/js/owl.lazyload.js
@@ -90,7 +90,7 @@
 
 		$elements.each($.proxy(function(index, element) {
 			var $element = $(element), image,
-				url = (window.devicePixelRatio > 1 && $element.attr('data-src-retina')) || $element.attr('data-src');
+                url = (window.devicePixelRatio > 1 && $element.attr('data-src-retina')) || $element.attr('data-src') || $element.attr('data-srcset');
 
 			this._core.trigger('load', { element: $element, url: url }, 'lazy');
 
@@ -99,6 +99,10 @@
 					$element.css('opacity', 1);
 					this._core.trigger('loaded', { element: $element, url: url }, 'lazy');
 				}, this)).attr('src', url);
+            } else if($element.is('source')) {
+                $element.one('load.owl.lazy', $.proxy(function() {
+                    this._core.trigger('loaded', { element: $element, url: url }, 'lazy');
+                }, this)).attr('srcset', url);
 			} else {
 				image = new Image();
 				image.onload = $.proxy(function() {


### PR DESCRIPTION
This PR does allow lazy loading for source tags.

Example code:
```html
<html>
	<head>
	    <link rel="stylesheet" href="https://owlcarousel2.github.io/OwlCarousel2/assets/owlcarousel/assets/owl.carousel.min.css">
	    <link rel="stylesheet" href="https://owlcarousel2.github.io/OwlCarousel2/assets/owlcarousel/assets/owl.theme.default.min.css">
		<script type="text/javascript" src="https://owlcarousel2.github.io/OwlCarousel2/assets/vendors/jquery.min.js"></script>
		<script type="text/javascript" src="https://cdn.rawgit.com/mimarcel/OwlCarousel2/fix/owl-lazy-for-source-tags/dist/owl.carousel.js"></script>
		<script>
			jQuery(function() {
				jQuery('.owl-carousel').owlCarousel({
					items: 1,
				    lazyLoad:true,
				    loop:true,
				    margin:10
				});
			});
		</script>
	</head>
	<body>
		<div class="owl-carousel owl-theme">
			<picture>
			  <source class="owl-lazy" media="(min-width: 650px)" data-srcset="https://placehold.it/650x650&text=1">
			  <source class="owl-lazy" media="(min-width: 350px)" data-srcset="https://placehold.it/350x350&text=2">
			  <img class="owl-lazy" data-src="https://placehold.it/650x650&text=1" alt="">
			</picture>
			<picture>
			  <source class="owl-lazy" media="(min-width: 650px)" data-srcset="https://placehold.it/650x650&text=3">
			  <source class="owl-lazy" media="(min-width: 350px)" data-srcset="https://placehold.it/350x350&text=4">
			  <img class="owl-lazy" data-src="https://placehold.it/650x650&text=3" alt="">
			</picture>
		</div>
	</body>
</html>
```
This above code does include <picture> and <source> tags to use different images depending on the screen size.
