### PR TITLE
Fixed Typo

### DIFF
--- a/docs/docs/dev-plugin-api.html
+++ b/docs/docs/dev-plugin-api.html
@@ -127,7 +127,7 @@
         optionName: &#39;value&#39;,
         optionName2: &#39;value&#39;
     }
-    //mehtods:
+    //methods:
     PluginName.prototype.method = function(){
     }
     //destroy:


### PR DESCRIPTION
Replaced the spelling of the word 'methods'.