### PR TITLE
Update readme with notice for old domain

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 Touch enabled [jQuery](https://jquery.com/) plugin that lets you create a beautiful, responsive carousel slider. **To get started, check out https://owlcarousel2.github.io/OwlCarousel2/.**
 
+**Notice:** The old Owl Carousel site (owlgraphic [dot] com) is no longer in use. Please delete all references to this in bookmarks and your own products' documentation as it's being used for malicious purposes.
+
 ## Quick start
 
 ### Install


### PR DESCRIPTION
I've discovered the old domain for owl carousel (owlgraphic [dot] com) has been purchased and is being used for spam, marketing and malware. People using Owl Carousel in their projects (on Themeforest etc) should remove all references to protect their own customers/users.