### PR TITLE
added the option to modify activeDotClass

### DIFF
--- a/src/js/owl.navigation.js
+++ b/src/js/owl.navigation.js
@@ -142,6 +142,7 @@
 		slideBy: 1,
 		dotClass: 'owl-dot',
 		dotsClass: 'owl-dots',
+		activeDotClass: 'active',
 		dots: true,
 		dotsEach: false,
 		dotsData: false,
@@ -309,8 +310,8 @@
 				this._controls.$absolute.children().slice(difference).remove();
 			}
 
-			this._controls.$absolute.find('.active').removeClass('active');
-			this._controls.$absolute.children().eq($.inArray(this.current(), this._pages)).addClass('active');
+			this._controls.$absolute.find('.' + settings.activeDotClass).removeClass(settings.activeDotClass);
+			this._controls.$absolute.children().eq($.inArray(this.current(), this._pages)).addClass(settings.activeDotClass);
 		}
 	};
 


### PR DESCRIPTION
### A summary of the issue and the browser/OS environment in which it occurs. If suitable, include the steps required to reproduce the bug.>
I had an issue customizing the activeDot class, this class is generated by owl-carousel and i couldn't control it.
i need that for my project, so i have opened a pull request with this feature so everyone could use it,
is there any reason that this feature wasn't published until today?
_____________
### `<url>` - a link to the reduced test case. You can use one of the following services:
this is an example for usage with the new 'feature', i used it for changing the 'active' class to 'new-active'
and as a resource i have locally issued new owl.carousel.js and uploaded it to my s3 bucket.
and as you can see - it gets the new class.
https://jsfiddle.net/danielkonimbo/jhgtwfv0/1/


_____________
### Any other information you want to share that is relevant to the issue being reported.
This might include the lines of code that you have identified as causing the bug, and potential solutions (and your opinions on their merits).
