### PR TITLE
Don't change directions when using slideBy

### DIFF
--- a/src/js/owl.carousel.js
+++ b/src/js/owl.carousel.js
@@ -1245,16 +1245,11 @@
 		var current = this.current(),
 			revert = null,
 			distance = position - this.relative(current),
-			direction = (distance > 0) - (distance < 0),
 			items = this._items.length,
 			minimum = this.minimum(),
 			maximum = this.maximum();
 
 		if (this.settings.loop) {
-			if (!this.settings.rewind && Math.abs(distance) > items / 2) {
-				distance += direction * -1 * items;
-			}
-
 			position = current + distance;
 			revert = ((position - minimum) % items + items) % items + minimum;
 

--- a/src/js/owl.carousel.js
+++ b/src/js/owl.carousel.js
@@ -332,6 +332,10 @@
 
 			repeat /= 2;
 
+			if (settings.loop && items.length && settings.stagePadding) {
+				repeat += 1;
+			}
+
 			while (repeat > 0) {
 				// Switch to only using appended clones
 				clones.push(this.normalize(clones.length / 2, true));
@@ -1253,9 +1257,22 @@
 			position = current + distance;
 			revert = ((position - minimum) % items + items) % items + minimum;
 
+			if (Math.abs(distance) > items / 2)	{
+				maximum += 1;
+			}
+
 			if (revert !== position && revert - distance <= maximum && revert - distance > 0) {
 				current = revert - distance;
 				position = revert;
+				this.reset(current);
+			} else if ( revert !== position && position < 0) {
+				current = revert - Math.floor(items / 2);
+
+				if (Math.abs(distance) > items / 2) {
+					current += Math.abs(distance) - Math.ceil(items / 2);
+				}
+
+				position = current + distance;
 				this.reset(current);
 			}
 		} else if (this.settings.rewind) {

--- a/src/js/owl.navigation.js
+++ b/src/js/owl.navigation.js
@@ -352,10 +352,8 @@
 			settings = this._core.settings;
 
 		if (settings.slideBy == 'page') {
-			position = $.inArray(this.current(), this._pages);
-			length = this._pages.length;
-			successor ? ++position : --position;
-			position = this._pages[((position % length) + length) % length].start;
+			position = this._core.relative(this._core.current());
+			successor ? position += settings.items : position -= settings.items;
 		} else {
 			position = this._core.relative(this._core.current());
 			length = this._core.items().length;


### PR DESCRIPTION
This fixes #984

I tested various configurations and I couldn't see why that special handling code when looping was needed.

I also changed slideBy: 'page' as that was also looping backwards