### PR TITLE
Add "aria-selected" Parameter to Navigation Elements

### DIFF
--- a/src/js/owl.navigation.js
+++ b/src/js/owl.navigation.js
@@ -89,7 +89,7 @@
 				}
 			}, this),
 			'changed.owl.carousel': $.proxy(function(e) {
-				if (e.namespace && e.property.name == 'position') {
+				if (e.namespace && e.property.name === 'position') {
 					this.draw();
 				}
 			}, this),
@@ -180,6 +180,7 @@
 		if (!settings.dotsData) {
 			this._templates = [ $('<button role="button">')
 				.addClass(settings.dotClass)
+				.attr("aria-selected", "false")
 				.append($('<span>'))
 				.prop('outerHTML') ];
 		}
@@ -310,7 +311,10 @@
 			}
 
 			this._controls.$absolute.find('.active').removeClass('active');
-			this._controls.$absolute.children().eq($.inArray(this.current(), this._pages)).addClass('active');
+			// Reset all dots to aria-selected=false
+			this._controls.$absolute.find('.' + settings.dotClass).attr("aria-selected", "false");
+			// Add active class and aria-selected=true to active navigation dot
+			this._controls.$absolute.children().eq($.inArray(this.current(), this._pages)).addClass('active').attr("aria-selected", "true");
 		}
 	};
 
@@ -351,14 +355,13 @@
 		var position, length,
 			settings = this._core.settings;
 
-		if (settings.slideBy == 'page') {
+		if (settings.slideBy === 'page') {
 			position = $.inArray(this.current(), this._pages);
 			length = this._pages.length;
 			successor ? ++position : --position;
 			position = this._pages[((position % length) + length) % length].start;
 		} else {
 			position = this._core.relative(this._core.current());
-			length = this._core.items().length;
 			successor ? position += settings.slideBy : position -= settings.slideBy;
 		}
 

--- a/src/scss/_theme.scss
+++ b/src/scss/_theme.scss
@@ -50,7 +50,7 @@
 				display: block;
 				-webkit-backface-visibility: visible;
 				transition: opacity 200ms ease;
-				border-radius: $dot-rounded;
+				border-radius: $owl-dot-rounded;
 			}
 
 			&.active,

--- a/test/index.html
+++ b/test/index.html
@@ -14,6 +14,7 @@
 		<script src="../src/js/owl.carousel.js" data-cover></script>
 		<script src="../src/js/owl.support.js" data-cover></script>
 		<script src="../src/js/owl.autoplay.js" data-cover></script>
+		<script src="../src/js/owl.navigation.js" data-cover></script>
 		<script src="unit/core.js" defer></script>
 		<script src="unit/autoplay.js" defer></script>
 	</head>

--- a/test/unit/core.js
+++ b/test/unit/core.js
@@ -136,5 +136,15 @@ test('destroy', function() {
 	equal(simple.get(0).outerHTML.replace(/\s{2,}/g, ''), expected, 'Outer HTML before create and after destroy is equal.');
 });
 
+test('accessibility options', function() {
+	expect(1);
+
+	$('#simple').owlCarousel().data('owl.carousel');
+
+	var activeNavElement = $('#simple').find('.owl-dot.active');
+
+	equal(activeNavElement.attr("aria-selected"),"true","Aria attribute is present and correct on the active navigation element");
+});
+
 start();
 


### PR DESCRIPTION
Since the navigation "dots" behave primarily like radio buttons, adding the `aria-selected` parameter to them and setting the active navigation element to `aria-selected=true` will help with accessibility.

This PR adds the `aria-selected` parameter to navigation elements and includes a unit test.  It also includes a fix to a typo in the `_theme.scss` file discovered when attempting to `grunt dist`.