### PR TITLE
First time animation missed.

### DIFF
--- a/src/js/owl.carousel.js
+++ b/src/js/owl.carousel.js
@@ -1032,6 +1032,7 @@
 			return;
 		}
 
+		let _speed = this._speed;
 		this._speed = 0;
 		this._current = position;
 
@@ -1040,6 +1041,7 @@
 		this.animate(this.coordinates(position));
 
 		this.release([ 'translate', 'translated' ]);
+		this._speed = _speed;
 	};
 
 	/**


### PR DESCRIPTION
With multiple carousels on any resize the _speed is reset to 0. After that first slide animation is missed. 
Line 1276 speed set to some value.
Line 1280 in update()->reset()  speed value lost.