### PR TITLE
Amends onDragEnd eventHandlers to touchend.core.owl

### DIFF
--- a/src/js/owl.carousel.js
+++ b/src/js/owl.carousel.js
@@ -745,7 +745,7 @@
 
 		if (this.settings.touchDrag){
 			this.$stage.on('touchstart.owl.core', $.proxy(this.onDragStart, this));
-			this.$stage.on('touchcancel.owl.core', $.proxy(this.onDragEnd, this));
+			this.$stage.on('touchend.owl.core', $.proxy(this.onDragEnd, this));
 		}
 	};
 


### PR DESCRIPTION
The existing onDragEnd callback events are incorrectly bound to non-existent `touchcancel.core.owl` event, resulting in them never triggering.

`touchend.owl.core` is the event fired when touch events finish.

This PR changes the eventRegistration to use the one which is triggered `touchend.core.owl`.